### PR TITLE
Add reproducer for #20

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ openapi-schema-validator
 About
 #####
 
-Openapi-schema-validator is a Python library that validates schema against:
+*openapi-schema-validator* is a Python library that validates schema against:
 
 * `OpenAPI Schema Specification v3.0 <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject>`__ which is an extended subset of the `JSON Schema Specification Wright Draft 00 <http://json-schema.org/>`__.
 * `OpenAPI Schema Specification v3.1 <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md#schemaObject>`__ which is an extended superset of the `JSON Schema Specification Draft 2020-12 <http://json-schema.org/>`__.
@@ -37,7 +37,6 @@ Alternatively you can download the code and install from the repository:
 .. code-block:: bash
 
    $ pip install -e git+https://github.com/p1c2u/openapi-schema-validator.git#egg=openapi_schema_validator
-
 
 Usage
 #####
@@ -92,7 +91,7 @@ To validate an OpenAPI v3.1 schema:
        ...
    ValidationError: Additional properties are not allowed ('city' was unexpected)
 
-if you want to disambiguate the expected schema version, import and use ``OAS31Validator``:
+If you want to disambiguate the expected schema version, import and use ``OAS31Validator``:
 
 .. code-block:: python
 
@@ -150,7 +149,7 @@ You can also check format for primitive types
 References
 **********
 
-You can resolve JOSN references by passing custon reference resolver
+You can resolve JSON references by passing custom reference resolver
 
 .. code-block:: python
 
@@ -204,6 +203,7 @@ For more information about reference resolver see `Resolving JSON References <ht
 
 Related projects
 ################
+
 * `openapi-core <https://github.com/p1c2u/openapi-core>`__
    Python library that adds client-side and server-side support for the OpenAPI.
 * `openapi-spec-validator <https://github.com/p1c2u/openapi-spec-validator>`__

--- a/tests/integration/test_validators.py
+++ b/tests/integration/test_validators.py
@@ -21,10 +21,13 @@ class TestOAS30ValidatorValidate:
             "integer",
             "number",
             "string",
+            "object",
         ],
     )
     def test_null(self, schema_type):
         schema = {"type": schema_type}
+        if schema_type == "object":
+            schema["properties"] = {"some_prop": {"type": "string"}}
         validator = OAS30Validator(schema)
         value = None
 
@@ -39,10 +42,13 @@ class TestOAS30ValidatorValidate:
             "integer",
             "number",
             "string",
+            "object",
         ],
     )
     def test_nullable(self, schema_type):
         schema = {"type": schema_type, "nullable": True}
+        if schema_type == "object":
+            schema["properties"] = {"some_prop": {"type": "string"}}
         validator = OAS30Validator(schema)
         value = None
 
@@ -439,7 +445,7 @@ class TestOAS30ValidatorValidate:
             ValidationError,
             match="reference '#/components/schemas/other' could not be resolved",
         ):
-            result = validator.validate({"discipline": "other"})
+            validator.validate({"discipline": "other"})
             assert False
 
 
@@ -452,10 +458,13 @@ class TestOAS31ValidatorValidate:
             "integer",
             "number",
             "string",
+            "object",
         ],
     )
     def test_null(self, schema_type):
         schema = {"type": schema_type}
+        if schema_type == "object":
+            schema["properties"] = {"some_prop": {"type": "string"}}
         validator = OAS31Validator(schema)
         value = None
 
@@ -470,10 +479,13 @@ class TestOAS31ValidatorValidate:
             "integer",
             "number",
             "string",
+            "object",
         ],
     )
     def test_nullable(self, schema_type):
         schema = {"type": [schema_type, "null"]}
+        if schema_type == "object":
+            schema["properties"] = {"some_prop": {"type": "string"}}
         validator = OAS31Validator(schema)
         value = None
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+minversion = 3.18.0
+requires = tox-poetry
+
+[testenv]
+extras =
+  rfc3339-validator
+  strict-rfc3339
+  isodate
+commands =
+  pytest {posargs:tests/}


### PR DESCRIPTION
Add a reproducer for #20. I was hoping to actually fix this issue in this PR, but I suspect fixing this will require more extensive changes than originally planned so I only add tests for now.

In addition to the reproducer for #20, I also add some other tests related to the nullable type, fix some typos in the README, and add a simple `tox.ini` file.

PS: As a long-term fix for #20, I'm thinking that we could remove the `include_nullable_validator` function and instead do an initial one time scan of the schema, setting `nullable = False` where it makes sense (i.e. wherever a sibling attribute wouldn't override it). To be able to do this though, we'd also need to do up front resolution of JSON references. I'm looking into this approach.

Commits:

- `Add tox file`
- `README: Correct some typos`
- `tests: Add tests for nullable object type`
- `tests: Add test for nullable refs`
