### PR TITLE
Include tests in sdist archives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Topic :: Software Development :: Libraries"
 ]
+include = [
+    {path = "tests", format = "sdist"},
+]
 
 [tool.poetry.dependencies]
 python = "^3.7.0"


### PR DESCRIPTION
Follow up of https://github.com/python-openapi/openapi-spec-validator/pull/199