### PR TITLE
Advertise type hints in classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Topic :: Software Development :: Libraries"
+    "Topic :: Software Development :: Libraries",
+    "Typing :: Typed",
 ]
 include = [
     {path = "tests", format = "sdist"},


### PR DESCRIPTION
As a way to see at a glance on PyPI.org whether the package has type hints.

Refs: #51