### PR TITLE
OAS 3.1/3.2 discriminator is annotation-only

### DIFF
--- a/openapi_schema_validator/validators.py
+++ b/openapi_schema_validator/validators.py
@@ -115,12 +115,10 @@ def _build_oas31_validator() -> Any:
         Draft202012Validator,
         {
             # adjusted to OAS
-            "allOf": oas_keywords.allOf,
-            "oneOf": oas_keywords.oneOf,
-            "anyOf": oas_keywords.anyOf,
             "pattern": oas_keywords.pattern,
             "description": oas_keywords.not_implemented,
             # fixed OAS fields
+            # discriminator is annotation-only in OAS 3.1+
             "discriminator": oas_keywords.not_implemented,
             "xml": oas_keywords.not_implemented,
             "externalDocs": oas_keywords.not_implemented,

--- a/tests/integration/test_validators.py
+++ b/tests/integration/test_validators.py
@@ -1107,6 +1107,79 @@ class TestOAS31ValidatorValidate(BaseTestOASValidatorValidate):
         ]
         assert any(error in str(excinfo.value) for error in errors)
 
+    def test_discriminator_is_annotation_only(self, validator_class):
+        schema = {
+            "components": {
+                "schemas": {
+                    "A": {
+                        "type": "object",
+                        "properties": {"kind": {"type": "string"}},
+                        "required": ["kind"],
+                    },
+                    "B": {
+                        "type": "object",
+                        "properties": {
+                            "kind": {"type": "string"},
+                            "other": {"type": "string"},
+                        },
+                        "required": ["kind"],
+                    },
+                }
+            },
+            "oneOf": [
+                {"$ref": "#/components/schemas/A"},
+                {"$ref": "#/components/schemas/B"},
+            ],
+            "discriminator": {"propertyName": "kind"},
+        }
+
+        validator = validator_class(schema)
+
+        # A payload valid for both schemas A and B
+        instance = {"kind": "B"}
+
+        # oneOf fails because it matches BOTH A and B, discriminator does not restrict it
+        with pytest.raises(ValidationError):
+            validator.validate(instance)
+
+    @pytest.mark.parametrize(
+        "mapping_ref",
+        [
+            "#/components/schemas/Missing",
+            "#missing-anchor",
+            "#bad/frag",
+        ],
+    )
+    def test_discriminator_unresolvable_reference_ignored(
+        self, validator_class, mapping_ref
+    ):
+        schema = {
+            "oneOf": [{"$ref": "#/components/schemas/MountainHiking"}],
+            "discriminator": {
+                "propertyName": "discipline",
+                "mapping": {"mountain_hiking": mapping_ref},
+            },
+            "components": {
+                "schemas": {
+                    "MountainHiking": {
+                        "type": "object",
+                        "properties": {
+                            "discipline": {"type": "string"},
+                            "length": {"type": "integer"},
+                        },
+                        "required": ["discipline", "length"],
+                    },
+                },
+            },
+        }
+
+        validator = validator_class(schema)
+
+        # It should not raise any referencing errors because discriminator mapping is annotation-only
+        validator.validate(
+            {"discipline": "mountain_hiking", "length": 10},
+        )
+
 
 class TestOAS32ValidatorValidate(TestOAS31ValidatorValidate):
     """OAS 3.2 uses the OAS 3.2 published dialect resources."""


### PR DESCRIPTION
The OAS 3.1 validator was inheriting custom `oneOf`/`anyOf`/`allOf` handlers that replace standard JSON Schema composition with discriminator-based `$ref` resolution (OAS 3.0 semantics). In OAS 3.1/3.2, `discriminator` is a pure annotation; composition validation is governed entirely by `oneOf`/`anyOf`/`allOf`. Removed those overrides so OAS 3.1/3.2 uses Draft 2020-12 semantics directly.

```python
# Before: OAS31Validator with discriminator would silently attempt ref resolution
schema = {
    "$schema": "https://spec.openapis.org/oas/3.1/dialect/2024-11-10",
    "oneOf": [
        {"type": "object", "properties": {"petType": {"const": "cat"}, "meow": {"type": "string"}}, "required": ["petType", "meow"]},
    ],
    "discriminator": {"propertyName": "petType"},
}
v = OAS31Validator(schema)
list(v.iter_errors({"petType": "cat", "meow": "purr"}))
# Was: [ValidationError: "... reference '#/components/schemas/cat' could not be resolved"]
# Now: []  — discriminator ignored, oneOf validates normally
```
